### PR TITLE
Allow users to disable default key mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ In the quickfix window, you can use:
     v    to open in vertical split
     gv   to open in vertical split silently
     q    to close the quickfix window
+
+Additionally, the plugin registers `<leader>ru` both in normal and insert mode
+for triggering it easily.  You can disable these default mappings by setting
+`g:rubocop_no_mappings` in your `.vimrc` file, and then remap them differently.
+
+For instance, to trigger RuboCop by pressing `<leader>r` you can put the following in
+your `.vimrc`:
+
+```viml
+let g:rubocop_no_mappings = 'true'
+nmap <leader>r :RuboCop<CR>
+```

--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -5,10 +5,6 @@
 " Version: 0.2
 " ----------------------------------------------------------------------------
 
-" Shortcuts for RuboCop
-nmap <Leader>ru :RuboCop<CR>
-imap <Leader>ru <ESC>:RuboCop<CR>
-
 if exists('g:loaded_vimrubocop') || &cp
   finish
 endif
@@ -65,3 +61,9 @@ function! s:RuboCop()
 endfunction
 
 command! RuboCop :call <SID>RuboCop()
+
+" Shortcuts for RuboCop
+if !exists("g:rubocop_no_mappings")
+  nmap <Leader>ru :RuboCop<CR>
+  imap <Leader>ru <ESC>:RuboCop<CR>
+endif


### PR DESCRIPTION
It would be nice if users could disable the default `<leader>ru` key mapping, in case they want to set their own, or if they don't want to have any key mappings at all, and trigger by issuing the command manually.

This also is important if someone already uses the combination `<leader>ru` already for some other purpose, avoiding the conflict. The plugin still behaves the same if the user takes no action to explicitly disable the default mappings.
