### PR TITLE
remove silent option for rubocop 0.12.0 compatibility

### DIFF
--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -43,7 +43,7 @@ function! s:RuboCop()
   let l:extra_args     = g:vimrubocop_extra_args
   let l:filename       = @%
   let l:rubocop_cmd    = g:vimrubocop_rubocop_cmd
-  let l:rubocop_opts   = ' '.l:extra_args.' --format emacs --silent'
+  let l:rubocop_opts   = ' '.l:extra_args.' --format emacs'
   if g:vimrubocop_config != ''
     let l:rubocop_opts = ' '.l:rubocop_opts.' --config '.g:vimrubocop_config
   endif


### PR DESCRIPTION
in rubocop v0.12.0 silent option is removed
using it will produce the following warning:

--silent options is dropped. `emacs` and `files` formatters no longer display summary.
