### PR TITLE
The insert mode mappings cause a delay when typing the <leader> key

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In the quickfix window, you can use:
     gv   to open in vertical split silently
     q    to close the quickfix window
 
-Additionally, the plugin registers `<Leader>ru` both in normal and insert mode
+Additionally, the plugin registers `<Leader>ru` in normal mode
 for triggering it easily. You can disable these default mappings by setting
 `g:vimrubocop_keymap` in your `.vimrc` file, and then remap them differently.
 

--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -69,5 +69,4 @@ command! RuboCop :call <SID>RuboCop()
 " Shortcuts for RuboCop
 if g:vimrubocop_keymap == 1
   nmap <Leader>ru :RuboCop<CR>
-  imap <Leader>ru <ESC>:RuboCop<CR>
 endif


### PR DESCRIPTION
`imap <Leader>ru <ESC>:RuboCop<CR>` cases a delay when typing the `<leader>` key in the insert mode. We may disable this map by default or map the command to a non-printable key sequence.
