### PR TITLE
Auto-correct support (with inline switches and completion)

### DIFF
--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -38,7 +38,12 @@ function! s:RuboCop(current_args)
   if g:vimrubocop_config != ''
     let l:rubocop_opts = ' '.l:rubocop_opts.' --config '.g:vimrubocop_config
   endif
+
   let l:rubocop_output  = system(l:rubocop_cmd.l:rubocop_opts.' '.l:filename)
+  if !empty(matchstr(l:rubocop_opts, '--auto-correct\|-\<a\>'))
+    "Reload file if using auto correct
+    edit
+  endif
   let l:rubocop_output  = substitute(l:rubocop_output, '\\"', "'", 'g')
   let l:rubocop_results = split(l:rubocop_output, "\n")
   cexpr l:rubocop_results

--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -30,6 +30,12 @@ if !exists('g:vimrubocop_keymap')
   let g:vimrubocop_keymap = 1
 endif
 
+let s:rubocop_switches = ['-l', '--lint', '-R', '--rails', '-a', '--auto-correct']
+
+function! s:RuboCopSwitches(...)
+  return join(s:rubocop_switches, "\n")
+endfunction
+
 function! s:RuboCop(current_args)
   let l:extra_args     = g:vimrubocop_extra_args
   let l:filename       = @%
@@ -60,7 +66,7 @@ function! s:RuboCop(current_args)
   exec "nnoremap <silent> <buffer> gv <C-W><CR><C-W>H<C-W>b<C-W>J"
 endfunction
 
-command! -nargs=? RuboCop :call <SID>RuboCop(<q-args>)
+command! -complete=custom,s:RuboCopSwitches -nargs=? RuboCop :call <SID>RuboCop(<q-args>)
 
 " Shortcuts for RuboCop
 if g:vimrubocop_keymap == 1

--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -30,11 +30,11 @@ if !exists('g:vimrubocop_keymap')
   let g:vimrubocop_keymap = 1
 endif
 
-function! s:RuboCop()
+function! s:RuboCop(current_args)
   let l:extra_args     = g:vimrubocop_extra_args
   let l:filename       = @%
   let l:rubocop_cmd    = g:vimrubocop_rubocop_cmd
-  let l:rubocop_opts   = ' '.l:extra_args.' --format emacs'
+  let l:rubocop_opts   = ' '.a:current_args.' '.l:extra_args.' --format emacs'
   if g:vimrubocop_config != ''
     let l:rubocop_opts = ' '.l:rubocop_opts.' --config '.g:vimrubocop_config
   endif
@@ -55,7 +55,7 @@ function! s:RuboCop()
   exec "nnoremap <silent> <buffer> gv <C-W><CR><C-W>H<C-W>b<C-W>J"
 endfunction
 
-command! RuboCop :call <SID>RuboCop()
+command! -nargs=? RuboCop :call <SID>RuboCop(<q-args>)
 
 " Shortcuts for RuboCop
 if g:vimrubocop_keymap == 1


### PR DESCRIPTION
Hi, I've made a few changes with the end goal of having auto-correct support within `:RuboCop`. The changes are:

* Parameters for `:RuboCop`, for example `:RuboCop -l -R`, a very basic form of completion is supported (a static list, ideally we would be parsing rubocop -h?)
* Reloading of the edited file when using `-a/--auto-correct`, so that changes made by rubocop appear immediately.