### PR TITLE
Added in a more verbose installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ Please note that the current version of the Vim RuboCop plugin requires RuboCop 
 
 ## Installation
 
-Obtain a copy of this plugin and place `rubocop.vim` in your Vim plugin directory.
+If you don't have a preferred installation method, you might want to use
+[pathogen.vim](https://github.com/tpope/vim-pathogen), and then simply copy and paste:
+
+```bash 
+cd ~/.vim/bundle
+git clone git@github.com:ngmy/vim-rubocop.git 
+```
 
 ## Usage
 


### PR DESCRIPTION
I love using vim-rubocop but I would like to have a bit more verbose installation documentation for ease of use. 

Hopefully this is basic enough to help in 9/10 installation tries.

Thanks,

Stephen
