### PR TITLE
Move extra_args to the end of the rubocop command

### DIFF
--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -42,9 +42,9 @@ function! s:RuboCop(current_args)
   let l:extra_args     = g:vimrubocop_extra_args
   let l:filename       = @%
   let l:rubocop_cmd    = g:vimrubocop_rubocop_cmd
-  let l:rubocop_opts   = ' '.a:current_args.' '.l:extra_args.' --format emacs'
+  let l:rubocop_opts   = ' --format emacs '.a:current_args.' '.l:extra_args
   if g:vimrubocop_config != ''
-    let l:rubocop_opts = ' '.l:rubocop_opts.' --config '.g:vimrubocop_config
+    let l:rubocop_opts = ' '.g:vimrubocop_config.' --config '.l:rubocop_opts
   endif
 
   let l:rubocop_output  = system(l:rubocop_cmd.l:rubocop_opts.' '.l:filename)


### PR DESCRIPTION
For some rubocop executables, a `--file` or `--path` option might be necessary to target a specific file to run the parser.  I myself use a modified form of [rubocop-git](https://github.com/m4i/rubocop-git) (with an addition to support the flags above, as well as the `--format` flag) instead of the default `rubocop` command to only look at offenses I have made in my branch.

To allow using `rubocop-git` using the `g:vimrubocop_rubocop_cmd`, the last argument in the string includes the `--file` argument to be paired up with the `l:filename` when running the `:RuboCop` command.

Swapping these arguments should retain the previous functionality just fine, while allowing for the use-case described above.

Note:  It was chosen to have `l:extra_args` last in the list versus `a:current_args` since a `--file` option is more useful to be applied to every call of `:RuboCop` instead of on-demand via the `a:current_args`.
