### PR TITLE
Silent mode, no cexpr if no violation is found

### DIFF
--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -32,7 +32,7 @@ if !exists('g:vimrubocop_keymap')
   let g:vimrubocop_keymap = 1
 endif
 
-let s:rubocop_switches = ['-l', '--lint', '-R', '--rails', '-a', '--auto-correct']
+let s:rubocop_switches = ['-l', '--lint', '-R', '--rails', '-a', '--auto-correct', '-s', '--silent']
 
 function! s:RuboCopSwitches(...)
   return join(s:rubocop_switches, "\n")
@@ -41,8 +41,9 @@ endfunction
 function! s:RuboCop(current_args)
   let l:extra_args     = g:vimrubocop_extra_args
   let l:filename       = @%
+  let l:silent         = matchstr(a:current_args, '--silent\|-\<s\>')
   let l:rubocop_cmd    = g:vimrubocop_rubocop_cmd
-  let l:rubocop_opts   = ' '.a:current_args.' '.l:extra_args.' --format emacs'
+  let l:rubocop_opts   = ' '. substitute(a:current_args, '--silent\|-\<s\>', '', '').' '.l:extra_args.' --format emacs'
   if g:vimrubocop_config != ''
     let l:rubocop_opts = ' '.l:rubocop_opts.' --config '.g:vimrubocop_config
   endif
@@ -54,18 +55,25 @@ function! s:RuboCop(current_args)
   endif
   let l:rubocop_output  = substitute(l:rubocop_output, '\\"', "'", 'g')
   let l:rubocop_results = split(l:rubocop_output, "\n")
-  cexpr l:rubocop_results
-  copen
-  " Shortcuts taken from Ack.vim - git://github.com/mileszs/ack.vim.git
-  exec "nnoremap <silent> <buffer> q :ccl<CR>"
-  exec "nnoremap <silent> <buffer> t <C-W><CR><C-W>T"
-  exec "nnoremap <silent> <buffer> T <C-W><CR><C-W>TgT<C-W><C-W>"
-  exec "nnoremap <silent> <buffer> o <CR>"
-  exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>"
-  exec "nnoremap <silent> <buffer> h <C-W><CR><C-W>K"
-  exec "nnoremap <silent> <buffer> H <C-W><CR><C-W>K<C-W>b"
-  exec "nnoremap <silent> <buffer> v <C-W><CR><C-W>H<C-W>b<C-W>J<C-W>t"
-  exec "nnoremap <silent> <buffer> gv <C-W><CR><C-W>H<C-W>b<C-W>J"
+  if len(l:rubocop_results) > 0
+    if empty(l:silent)
+      cexpr l:rubocop_results
+      copen
+      " Shortcuts taken from Ack.vim - git://github.com/mileszs/ack.vim.git
+      exec "nnoremap <silent> <buffer> q :ccl<CR>"
+      exec "nnoremap <silent> <buffer> t <C-W><CR><C-W>T"
+      exec "nnoremap <silent> <buffer> T <C-W><CR><C-W>TgT<C-W><C-W>"
+      exec "nnoremap <silent> <buffer> o <CR>"
+      exec "nnoremap <silent> <buffer> go <CR><C-W><C-W>"
+      exec "nnoremap <silent> <buffer> h <C-W><CR><C-W>K"
+      exec "nnoremap <silent> <buffer> H <C-W><CR><C-W>K<C-W>b"
+      exec "nnoremap <silent> <buffer> v <C-W><CR><C-W>H<C-W>b<C-W>J<C-W>t"
+      exec "nnoremap <silent> <buffer> gv <C-W><CR><C-W>H<C-W>b<C-W>J"
+    end
+  else
+    echom 'Rubocop reports no violations'
+  endif
+
 endfunction
 
 command! -complete=custom,s:RuboCopSwitches -nargs=? RuboCop :call <SID>RuboCop(<q-args>)


### PR DESCRIPTION
If you use rubocop -a as autocmd on save, it will always open a cexpr.
This is quite irritating. This commits add a silent flag (--silent, -s) to supress this behaviour.
Also it prevents the cexpr to be shown if no violation is found, and shows a message instead.
In my opinion this should always be on, since it is useless to open an empty cexpr. But feel free to make it configurable if wanted.