### PR TITLE
Use `get(g:, ...)` to read config

### DIFF
--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -15,23 +15,6 @@ let g:loaded_vimrubocop = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-if !exists('g:vimrubocop_rubocop_cmd')
-  let g:vimrubocop_rubocop_cmd = 'rubocop '
-endif
-
-" Options
-if !exists('g:vimrubocop_config')
-  let g:vimrubocop_config = ''
-endif
-
-if !exists('g:vimrubocop_extra_args')
-  let g:vimrubocop_extra_args = ''
-endif
-
-if !exists('g:vimrubocop_keymap')
-  let g:vimrubocop_keymap = !exists('no_plugin_maps')
-endif
-
 let s:rubocop_switches = ['-l', '--lint', '-R', '--rails', '-a', '--auto-correct']
 
 function! s:RuboCopSwitches(...)
@@ -39,11 +22,11 @@ function! s:RuboCopSwitches(...)
 endfunction
 
 function! s:RuboCop(current_args)
-  let l:extra_args     = g:vimrubocop_extra_args
+  let l:extra_args     = get(g:, 'vimrubocop_extra_args', '')
   let l:filename       = @%
-  let l:rubocop_cmd    = g:vimrubocop_rubocop_cmd
+  let l:rubocop_cmd    = get(g:, 'vimrubocop_rubocop_cmd', 'rubocop ')
   let l:rubocop_opts   = ' '.a:current_args.' '.l:extra_args.' --format emacs'
-  if g:vimrubocop_config != ''
+  if get(g:, 'vimrubocop_config', '') != ''
     let l:rubocop_opts = ' '.l:rubocop_opts.' --config '.g:vimrubocop_config
   endif
 
@@ -71,7 +54,7 @@ endfunction
 command! -complete=custom,s:RuboCopSwitches -nargs=? RuboCop :call <SID>RuboCop(<q-args>)
 
 " Shortcuts for RuboCop
-if g:vimrubocop_keymap == 1
+if get(g:, 'vimrubocop_keymap', !exists('no_plugin_maps'))
   nmap <Leader>ru :RuboCop<CR>
 endif
 

--- a/plugin/rubocop.vim
+++ b/plugin/rubocop.vim
@@ -29,7 +29,7 @@ if !exists('g:vimrubocop_extra_args')
 endif
 
 if !exists('g:vimrubocop_keymap')
-  let g:vimrubocop_keymap = 1
+  let g:vimrubocop_keymap = !exists('no_plugin_maps')
 endif
 
 let s:rubocop_switches = ['-l', '--lint', '-R', '--rails', '-a', '--auto-correct']


### PR DESCRIPTION
Don't pollute global variable space with this plugin's config if we don't have to.

get( {list}, {idx}, {def} ) has been part of Vim since version 7.0033 (2005-01-07).

This change also merges #27, however if you like I can modify it so that it doesn't.